### PR TITLE
Auto detect standard or rubocop by dotfile presence

### DIFF
--- a/doc/ruby-lsp.txt
+++ b/doc/ruby-lsp.txt
@@ -35,6 +35,9 @@ The automatic installation of the `ruby-lsp` gem can be disabled by passing
 The (experimental) launcher of the `ruby-lsp` can be enabled by passing
 `use_launcher = true` in the `config` table.
 
+The automatic detection of Standard or Rubocop can be disabled by passing
+`autodetect_tools = false` in the `config` table.
+
 Any `lspconfig` valid tables can be passed through the `lspconfig` key in the
 `config` table, which will be merged with the default `lspconfig`.
 

--- a/doc/ruby-lsp.txt
+++ b/doc/ruby-lsp.txt
@@ -35,8 +35,8 @@ The automatic installation of the `ruby-lsp` gem can be disabled by passing
 The (experimental) launcher of the `ruby-lsp` can be enabled by passing
 `use_launcher = true` in the `config` table.
 
-The automatic detection of Standard or Rubocop can be disabled by passing
-`autodetect_tools = false` in the `config` table.
+The automatic detection of Standard or Rubocop can be enabled by passing
+`autodetect_tools = true` in the `config` table.
 
 Any `lspconfig` valid tables can be passed through the `lspconfig` key in the
 `config` table, which will be merged with the default `lspconfig`.

--- a/lua/ruby-lsp/init.lua
+++ b/lua/ruby-lsp/init.lua
@@ -138,18 +138,6 @@ ruby_lsp.config = {
     on_attach = function(client, buffer)
       create_autocmds(client, buffer)
     end,
-    before_init = function(_params, config)
-      if ruby_lsp.options.autodetect_tools then
-        local tool = detect_tool()
-
-        if tool then
-          config.init_options = vim.tbl_extend('force', config.init_options or {}, {
-            formatter = tool,
-            linters = { tool },
-          })
-        end
-      end
-    end,
   },
 }
 
@@ -166,6 +154,17 @@ ruby_lsp.setup = function(config)
 
       if ruby_lsp.options.use_launcher then
         table.insert(c.cmd, '--use-launcher')
+      end
+
+      if ruby_lsp.options.autodetect_tools then
+        local tool = detect_tool()
+
+        if tool then
+          c.init_options = vim.tbl_extend('force', c.init_options or {}, {
+            formatter = tool,
+            linters = { tool },
+          })
+        end
       end
     end
   end)

--- a/lua/ruby-lsp/init.lua
+++ b/lua/ruby-lsp/init.lua
@@ -24,10 +24,6 @@ local function configure_lspconfig(config)
   lspconfig.ruby_lsp.setup(config)
 end
 
-local function is_ruby_lsp_installed()
-  return vim.fn.executable('ruby-lsp') == 1
-end
-
 local function update_ruby_lsp(callback)
   vim.notify('Updating ruby-lsp...')
 
@@ -50,6 +46,18 @@ local function update_ruby_lsp(callback)
       end
     end
   }):start()
+end
+
+local function is_ruby_lsp_installed()
+  return vim.fn.executable('ruby-lsp') == 1
+end
+
+local function is_standard()
+  return vim.fn.filereadable('.standard.yml') == 1
+end
+
+local function is_rubocop()
+  return vim.fn.filereadable('.rubocop.yml') == 1
 end
 
 local function create_autocmds(client, buffer)
@@ -111,6 +119,16 @@ local function install_ruby_lsp(callback)
   }):start()
 end
 
+local function detect_tool()
+  if is_standard() then
+    return 'standard'
+  end
+
+  if is_rubocop() then
+    return 'rubocop'
+  end
+end
+
 ruby_lsp.config = {
   auto_install = true,
   use_launcher = false, -- Use experimental launcher
@@ -118,6 +136,16 @@ ruby_lsp.config = {
     mason = false, -- Prevent LazyVim from installing via Mason
     on_attach = function(client, buffer)
       create_autocmds(client, buffer)
+    end,
+    before_init = function(_params, config)
+      local tool = detect_tool()
+
+      if tool then
+        config.init_options = vim.tbl_extend('force', config.init_options or {}, {
+          formatter = tool,
+          linters = { tool },
+        })
+      end
     end,
   },
 }

--- a/lua/ruby-lsp/init.lua
+++ b/lua/ruby-lsp/init.lua
@@ -132,7 +132,7 @@ end
 ruby_lsp.config = {
   auto_install = true,
   use_launcher = false, -- Use experimental launcher
-  autodetect_tools = true,
+  autodetect_tools = false, -- Autodetect the formatting and linting tools
   lspconfig = {
     mason = false, -- Prevent LazyVim from installing via Mason
     on_attach = function(client, buffer)

--- a/lua/ruby-lsp/init.lua
+++ b/lua/ruby-lsp/init.lua
@@ -132,19 +132,22 @@ end
 ruby_lsp.config = {
   auto_install = true,
   use_launcher = false, -- Use experimental launcher
+  autodetect_tools = true,
   lspconfig = {
     mason = false, -- Prevent LazyVim from installing via Mason
     on_attach = function(client, buffer)
       create_autocmds(client, buffer)
     end,
     before_init = function(_params, config)
-      local tool = detect_tool()
+      if ruby_lsp.options.autodetect_tools then
+        local tool = detect_tool()
 
-      if tool then
-        config.init_options = vim.tbl_extend('force', config.init_options or {}, {
-          formatter = tool,
-          linters = { tool },
-        })
+        if tool then
+          config.init_options = vim.tbl_extend('force', config.init_options or {}, {
+            formatter = tool,
+            linters = { tool },
+          })
+        end
       end
     end,
   },


### PR DESCRIPTION
Look for the presence of a Rubocop or Standard config file, and then set the formatter and linters to the detected tool.

Opt-in for now, by setting `autodetect_tools = true` when configuring the plugin.

```lua
require('ruby-lsp').setup({
  autodetect_tools = true
})
```